### PR TITLE
Added `--ignore-unmonitored, -m` option to ignore any checks that are unmonitored which would normally trigger an unknown status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Added
+- Added `--ignore-unmonitored, -m` option to ignore any checks that are unmonitored which would normally trigger an unknown status @rwky
+
 ### Changed
 - Change `sensu-plugin` dependency to `~> 1.2` (@eheydrick)
 

--- a/bin/check-monit-status.rb
+++ b/bin/check-monit-status.rb
@@ -51,6 +51,12 @@ class CheckMonit < Sensu::Plugin::Check::CLI
          short: '-i ignore',
          default: ''
 
+  option :ignore_unmonitored,
+         long: '--ignore-unmonitored',
+         short: '-m',
+         default: false,
+         boolean: true
+
   def run
     status_doc = REXML::Document.new(monit_status)
     ignored = config[:ignore].split(',')
@@ -61,7 +67,7 @@ class CheckMonit < Sensu::Plugin::Check::CLI
       status = svc.elements['status'].text
 
       next if ignored.include? name
-
+      next if monitored == '0' && config[:ignore_unmonitored]
       unknown "#{name} status unkown" unless %w( 1 5 ).include? monitored
       critical "#{name} status failed" unless status == '0'
     end


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**

No

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 
